### PR TITLE
Making the discount value positive

### DIFF
--- a/Gateway/Request/PaymentsRequest.php
+++ b/Gateway/Request/PaymentsRequest.php
@@ -157,7 +157,7 @@ class PaymentsRequest
         if ($transactionAmount > $orderAmount) {
             $discountAmount = $transactionAmount - $orderAmount;
         }
-        return $discountAmount;
+        return abs($discountAmount);
     }
 
     protected function getPriceAdditional(Order $order, float $orderAmount): float


### PR DESCRIPTION
**Making the discount value positive:**

**Description:**
The discount value was sent as negative to Vindi, and it returned an error “o desconto deve ser igual ou maior que zero”. It has therefore been fixed to show the discount as a positive value

**Checklist:**
- [x] Changes are consistent with the project's coding style.
- [ ] Documentation (if applicable) has been updated.
- [ ] Link to related issue (if applicable):

**Testing Instructions:**
