### PR TITLE
The payment link delete has been removed from the payment link page

### DIFF
--- a/view/frontend/templates/custom/payment-link.phtml
+++ b/view/frontend/templates/custom/payment-link.phtml
@@ -14,7 +14,6 @@ $paymentLink = $block->getPaymentLink();
     $customer = $block->getCustomerById($order->getCustomerId());
     $billingAddress = $order->getBillingAddress();
     $instructions = $block->getInstructions();
-    $block->deletePaymentLink($paymentLink);
 ?>
 <div class="vindi-link-container">
     <div class="customer-data">


### PR DESCRIPTION
**Removing the payment link delete from payment link page:**

**Description:**
It was requested that the delete functionality be removed when the customer visits the payment link page. Now, it will only be removed when the link expires

**Checklist:**
- [ ] Changes are consistent with the project's coding style.
- [ ] Documentation (if applicable) has been updated.
- [ ] Link to related issue (if applicable):

**Testing Instructions:**
